### PR TITLE
Fix list of requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ First, make sure you have all of the following Python packages installed:
 * numpy
 * scipy
 * matplotlib
-* sklearn
+* scikit-learn
+* pandas
 * sompy
 * joblib
 * portalocker


### PR DESCRIPTION
I added Pandas to the list of requires packages for the "Way 3" installation. I also changed `sklearn` to `scikit-learn`, which is the PyPI name of the package.