### PR TITLE
Increase transparency of lines in the graphs

### DIFF
--- a/clust/scripts/graphics.py
+++ b/clust/scripts/graphics.py
@@ -138,7 +138,7 @@ def plotclusters(X, B, filename, DatasetsNames, conditions, GDM=None, Cs='all', 
                 localX = X[l][B[:, Cs[k]], :]
             else:
                 localX = X[l][B[GDM[:, l], Cs[k]], :]
-            plt.plot(np.arange(localX.shape[1]), np.transpose(localX), 'k-')
+            plt.plot(np.arange(localX.shape[1]), np.transpose(localX), 'k-', alpha=0.15)
             plt.xticks(np.arange(localX.shape[1]), conditions[l], rotation=xticksrotation)
 
 


### PR DESCRIPTION
As the expressions clusters plots usually display a large number of genes, it's difficult to distinguish the lines when they are fully opaque. I experimented reducing the opacity to 15% to make it easier to see the distribution of the lines in the cluster.

![screenshot from 2018-11-14 10 51 07](https://user-images.githubusercontent.com/22940964/48483687-48dc3a00-e7fb-11e8-99d6-964211a7074a.png)
![screenshot from 2018-11-14 10 51 29](https://user-images.githubusercontent.com/22940964/48483688-48dc3a00-e7fb-11e8-9fdb-cd953feff038.png)
